### PR TITLE
fix(RangeInYear) `start_day` and `end_day` with `start_month == end_month`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 * Add `Expression::Difference` for set differences between 2 schedules ([@danott][])
 * Allow `Expression::DayInMonth` to take `:last` (or `'last'`) for its `day:` argument ([@PatrickLerner][])
+* Fix `Expression::RangeInYear` to properly handle using `start_day` and `end_day` when `start_month == end_month` ([@danielma][])
 
 [Commits](https://github.com/molawson/repeatable/compare/v0.5.0...master)
 
@@ -71,3 +72,4 @@ Initial Release
 
 [@danott]: https://github.com/danott
 [@PatrickLerner]: https://github.com/PatrickLerner
+[@danielma]: https://github.com/danielma

--- a/lib/repeatable/expression/range_in_year.rb
+++ b/lib/repeatable/expression/range_in_year.rb
@@ -9,7 +9,13 @@ module Repeatable
       end
 
       def include?(date)
-        months_include?(date) || start_month_include?(date) || end_month_include?(date)
+        return true if months_include?(date)
+
+        if start_month == end_month
+          start_month_include?(date) && end_month_include?(date)
+        else
+          start_month_include?(date) || end_month_include?(date)
+        end
       end
 
       def to_h

--- a/spec/repeatable/expression/range_in_year_spec.rb
+++ b/spec/repeatable/expression/range_in_year_spec.rb
@@ -123,6 +123,20 @@ module Repeatable
             expect(subject).not_to include(::Date.new(2015, 11, 1))
           end
         end
+
+        context 'start month equals end month' do
+          let(:args) { { start_month: 8, end_month: 8, start_day: 20, end_day: 21 } }
+
+          it 'return true when the date falls on or after the start_day in the start_month' do
+            expect(subject).to include(::Date.new(2015, 8, 20))
+            expect(subject).to include(::Date.new(2015, 8, 21))
+          end
+
+          it 'return false when the date falls outside the start_day in the start_month' do
+            expect(subject).not_to include(::Date.new(2015, 8, 19))
+            expect(subject).not_to include(::Date.new(2015, 8, 22))
+          end
+        end
       end
 
       describe '#to_h' do


### PR DESCRIPTION
Fix an issue with `Expression::RangeInYear` where `start_day` and `end_day` would not be properly respected if `start_month == end_month`.